### PR TITLE
docs: retitle README to "Real Estate Listing API for Zillow" + non-affiliation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Real Estate Listing API for Zillow
+
+_HasData is an independent service, not affiliated with, endorsed by, or sponsored by Zillow Group, Inc. Zillow is a trademark of its respective owner._
 
 ## What is Zillow and How to Scrape It
 


### PR DESCRIPTION
## What

- Add `# Real Estate Listing API for Zillow` as the README H1 (the README previously had no top-level title).
- Add a non-affiliation disclaimer directly under the title.

The repository is **not** renamed — URL, clones, package name, and existing links are all preserved.

> The repo **description** was also updated to "Real Estate Listing API for Zillow" via repo settings (not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)